### PR TITLE
feat: centralize vehicle data option helpers

### DIFF
--- a/src/app/api/discover/filters/route.ts
+++ b/src/app/api/discover/filters/route.ts
@@ -1,273 +1,67 @@
 import { NextResponse } from "next/server";
-import { getServerSupabase } from "@/lib/supabase";
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { getYears, getMakes, getModels, getTrims, getDistinctOptions } from "@/lib/vehicle-data/options";
 
-const YEAR_CANDIDATES = ["year", "model_year", "Year"] as const;
-const MAKE_CANDIDATES = ["make", "brand", "Make"] as const;
-const MODEL_CANDIDATES = ["model", "Model"] as const;
-const TRIM_CANDIDATES = ["trim", "Trim"] as const;
-const BODY_CANDIDATES = ["body_type", "body_style", "Body type", "Body style"] as const;
-const CLASS_CANDIDATES = ["car_classification", "class", "segment", "Car classification", "Classification"] as const;
-const DRIVE_CANDIDATES = ["drive_type", "drivetrain", "drive", "Drive type", "Drivetrain"] as const;
-const TRANS_CANDIDATES = ["transmission", "transmission_type", "Transmission", "Transmission type"] as const;
-const ENGINE_CANDIDATES = ["engine_type", "engine_configuration", "engine", "engine_config", "Engine configuration", "Engine"] as const;
-const DOORS_CANDIDATES = ["doors", "Doors"] as const;
-const SEATING_CANDIDATES = ["total_seating", "seating", "seats", "Total seating", "Seating", "Seats"] as const;
-const FUEL_CANDIDATES = ["fuel_type", "fuel", "Fuel type"] as const;
-const COUNTRY_CANDIDATES = ["country_of_origin", "origin", "country", "Country of origin", "Origin", "Country"] as const;
-
-type Columns = {
-  year: string;
-  make: string;
-  model: string;
-  trim: string;
-  body: string;
-  classification: string;
-  drive: string;
-  transmission: string;
-  engine: string;
-  doors: string;
-  seating: string;
-  fuel: string;
-  country: string;
-};
-
-function pickColumn(row: Record<string, unknown> | null, candidates: string[]): string {
-  if (!row) return candidates[0] ?? "";
-  for (const c of candidates) {
-    if (c in row) return c;
-  }
-  return candidates[0] ?? "";
-}
-
-function present(row: Record<string, unknown> | null, candidates: readonly string[]): string[] {
-  if (!row) return [...candidates];
-  return candidates.filter((c) => c in row);
-}
-
-async function selectDistinctCursor(
-  supabase: SupabaseClient,
-  column: string,
-  filters?: Array<{ col: string; val: string }>,
-  pageSize = 10000,
-  maxPages = 200
-): Promise<string[]> {
-  try {
-    const seen = new Set<string>();
-    let last: string | null = null;
-    for (let page = 0; page < maxPages; page++) {
-      let q = supabase
-        .from("vehicle_data")
-        .select(column)
-        .not(column, "is", null)
-        .order(column, { ascending: true });
-      if (filters) for (const f of filters) q = q.eq(f.col, f.val);
-      if (last !== null) q = q.gt(column, last);
-      const { data } = await q.limit(pageSize);
-      const rows = Array.isArray(data) ? (data as unknown as Array<Record<string, unknown>>) : [];
-      if (rows.length === 0) break;
-      for (const row of rows) {
-        const valRaw = row[column as keyof typeof row];
-        const val = valRaw == null ? "" : String(valRaw);
-        if (val) {
-          seen.add(val);
-          last = val;
-        }
-      }
-      if (rows.length < pageSize) break;
-      if (seen.size > 100000) break;
-    }
-    return Array.from(seen);
-  } catch {
-    return [];
-  }
-}
-
-async function selectDistinctMany(
-  supabase: SupabaseClient,
-  columns: string[],
-  filters?: Array<{ col: string; val: string }>,
-  pageSize?: number
-): Promise<string[]> {
-  let agg: string[] = [];
-  for (const col of columns) {
-    const vals = await selectDistinctCursor(supabase, col, filters, pageSize ?? 10000);
-    agg = agg.concat(vals);
-    if (agg.length > 100000) break;
-  }
-  return Array.from(new Set(agg.map(String)));
-}
-
-async function selectDistinct(
-  supabase: Awaited<ReturnType<typeof getServerSupabase>>,
-  column: string,
-  filters?: Array<{ col: string; val: string }>,
-  limit = 2000
-): Promise<string[]> {
-  if (!column) return [];
-  try {
-    let q = supabase.from("vehicle_data").select(column, { head: false, count: "planned" }).not(column, "is", null);
-    if (filters) for (const f of filters) q = q.eq(f.col, f.val);
-    const { data } = await q.order(column as string, { ascending: true }).limit(limit);
-    const rows = (data as Array<Record<string, string | number>> | null) ?? [];
-    return Array.from(new Set(rows.map(v => String(v[column as keyof typeof v])))).filter(Boolean);
-  } catch {
-    return [];
-  }
-}
+export const dynamic = "force-dynamic";
 
 export async function GET(req: Request): Promise<Response> {
   try {
-    // Prefer service-role server-side to ensure public filter reads regardless of anon RLS
-    const adminUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
-    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-    const supabase: SupabaseClient = (adminUrl && serviceKey)
-      ? createClient(adminUrl, serviceKey, { auth: { persistSession: false } })
-      : await getServerSupabase();
-    // Single probe to infer columns
-    const probe = await supabase.from("vehicle_data").select("*").limit(1);
-    const row = Array.isArray(probe.data) && probe.data.length > 0 ? (probe.data[0] as Record<string, unknown>) : null;
-
-    const columns: Columns = {
-      year: pickColumn(row, [...YEAR_CANDIDATES]) || "",
-      make: pickColumn(row, [...MAKE_CANDIDATES]) || "",
-      model: pickColumn(row, [...MODEL_CANDIDATES]) || "",
-      trim: pickColumn(row, [...TRIM_CANDIDATES]) || "",
-      body: pickColumn(row, [...BODY_CANDIDATES]) || "",
-      classification: pickColumn(row, [...CLASS_CANDIDATES]) || "",
-      drive: pickColumn(row, [...DRIVE_CANDIDATES]) || "",
-      transmission: pickColumn(row, [...TRANS_CANDIDATES]) || "",
-      engine: pickColumn(row, [...ENGINE_CANDIDATES]) || "",
-      doors: pickColumn(row, [...DOORS_CANDIDATES]) || "",
-      seating: pickColumn(row, [...SEATING_CANDIDATES]) || "",
-      fuel: pickColumn(row, [...FUEL_CANDIDATES]) || "",
-      country: pickColumn(row, [...COUNTRY_CANDIDATES]) || "",
-    };
-
-    const yearCols = present(row, YEAR_CANDIDATES as unknown as string[]);
-    const makeCols = present(row, MAKE_CANDIDATES as unknown as string[]);
-    const modelCols = present(row, MODEL_CANDIDATES as unknown as string[]);
-    const trimCols = present(row, TRIM_CANDIDATES as unknown as string[]);
-    const bodyCols = present(row, BODY_CANDIDATES as unknown as string[]);
-    const classCols = present(row, CLASS_CANDIDATES as unknown as string[]);
-    const driveCols = present(row, DRIVE_CANDIDATES as unknown as string[]);
-    const transCols = present(row, TRANS_CANDIDATES as unknown as string[]);
-    const engineCols = present(row, ENGINE_CANDIDATES as unknown as string[]);
-    const doorsCols = present(row, DOORS_CANDIDATES as unknown as string[]);
-    const seatingCols = present(row, SEATING_CANDIDATES as unknown as string[]);
-    const fuelCols = present(row, FUEL_CANDIDATES as unknown as string[]);
-    const countryCols = present(row, COUNTRY_CANDIDATES as unknown as string[]);
-
-    // Parse current selections from query string to constrain option lists
     const url = new URL(req.url);
-    const selYear = url.searchParams.get("year") || undefined;
-    const selMake = url.searchParams.get("make") || undefined;
-    const selModel = url.searchParams.get("model") || undefined;
-    const selTrim = url.searchParams.get("trim") || undefined;
+    const year = url.searchParams.get("year") || undefined;
+    const make = url.searchParams.get("make") || undefined;
+    const model = url.searchParams.get("model") || undefined;
+    const trim = url.searchParams.get("trim") || undefined;
 
-    const baseFilters: Array<{ col: string; val: string }> = [];
-    if (selYear && columns.year) baseFilters.push({ col: columns.year, val: selYear });
-    // We only include make/model/trim in base for non-dependent lists so they narrow too
-    if (selMake && columns.make) baseFilters.push({ col: columns.make, val: selMake });
-    if (selModel && columns.model) baseFilters.push({ col: columns.model, val: selModel });
-    if (selTrim && columns.trim) baseFilters.push({ col: columns.trim, val: selTrim });
+    const baseFilters: Record<string, string | number> = {};
+    if (year) baseFilters.year = Number(year);
+    if (make) baseFilters.make = make;
+    if (model) baseFilters.model = model;
+    if (trim) baseFilters.trim = trim;
 
-    // Years: Always return full UX range 1990..2026 (descending)
-    const years: string[] = Array.from({ length: 2026 - 1990 + 1 }, (_, i) => String(2026 - i));
+    const [years, makes, models, trims, body, classification, drive, transmission, engine, doorsRaw, seatingRaw, fuel, country] = await Promise.all([
+      getYears(),
+      getMakes(year),
+      getModels(year, make),
+      getTrims(year, make, model),
+      getDistinctOptions("body_type", baseFilters),
+      getDistinctOptions("car_classification", baseFilters),
+      getDistinctOptions("drive_type", baseFilters),
+      getDistinctOptions("transmission", baseFilters),
+      getDistinctOptions("engine_configuration", baseFilters),
+      getDistinctOptions("doors", baseFilters),
+      getDistinctOptions("seating", baseFilters),
+      getDistinctOptions("fuel_type", baseFilters),
+      getDistinctOptions("country_of_origin", baseFilters),
+    ]);
 
-    // Dependent lists: make depends on year; model depends on year+make; trim depends on year+make+model
-    // Build filters against all possible columns to avoid truncation when data is split across multiple columns
-    const makeFiltersSets = selYear ? yearCols.map((c) => [{ col: c, val: selYear }]) : [undefined];
-    const modelFiltersSets = (selYear || selMake)
-      ? [
-          ...(
-            selYear ? yearCols.map((c) => [{ col: c, val: selYear }]) : [ [] as Array<{ col: string; val: string }> ]
-          ).map((arr) => (selMake ? [...arr, ...makeCols.map((m) => ({ col: m, val: selMake }))] : arr))
-        ]
-      : [undefined];
-    const trimFiltersSets = (selYear || selMake || selModel)
-      ? [
-          ...(
-            selYear ? yearCols.map((c) => [{ col: c, val: selYear }]) : [ [] as Array<{ col: string; val: string }> ]
-          ).map((arr) => {
-            let cur = arr;
-            if (selMake) cur = [...cur, ...makeCols.map((m) => ({ col: m, val: selMake }))];
-            if (selModel) cur = [...cur, ...modelCols.map((m) => ({ col: m, val: selModel }))];
-            return cur;
-          })
-        ]
-      : [undefined];
+    const doors = doorsRaw.sort((a, b) => Number(a) - Number(b));
+    const seating = seatingRaw.sort((a, b) => Number(a) - Number(b));
 
-    // Compute options by unioning across present columns with cursor-based scanning
-    const make = await (async () => {
-      let agg: string[] = [];
-      for (const f of makeFiltersSets) {
-        const vals = await selectDistinctMany(supabase, makeCols.length ? makeCols : [columns.make], f);
-        agg = agg.concat(vals);
-        if (agg.length > 100000) break;
-      }
-      return Array.from(new Set(agg.map(String))).sort((a, b) => a.localeCompare(b));
-    })();
-
-    const model = await (async () => {
-      let agg: string[] = [];
-      for (const f of modelFiltersSets) {
-        const vals = await selectDistinctMany(supabase, modelCols.length ? modelCols : [columns.model], f);
-        agg = agg.concat(vals);
-        if (agg.length > 100000) break;
-      }
-      return Array.from(new Set(agg.map(String))).sort((a, b) => a.localeCompare(b));
-    })();
-
-    const trim = await (async () => {
-      let agg: string[] = [];
-      for (const f of trimFiltersSets) {
-        const vals = await selectDistinctMany(supabase, trimCols.length ? trimCols : [columns.trim], f);
-        agg = agg.concat(vals);
-        if (agg.length > 100000) break;
-      }
-      return Array.from(new Set(agg.map(String))).sort((a, b) => a.localeCompare(b));
-    })();
-
-    const body = (await selectDistinctMany(supabase, bodyCols.length ? bodyCols : [columns.body])).sort((a, b) => a.localeCompare(b));
-    const classification = (await selectDistinctMany(supabase, classCols.length ? classCols : [columns.classification])).sort((a, b) => a.localeCompare(b));
-    const drive = (await selectDistinctMany(supabase, driveCols.length ? driveCols : [columns.drive])).sort((a, b) => a.localeCompare(b));
-    const transmission = (await selectDistinctMany(supabase, transCols.length ? transCols : [columns.transmission])).sort((a, b) => a.localeCompare(b));
-    const engine = (await selectDistinctMany(supabase, engineCols.length ? engineCols : [columns.engine])).sort((a, b) => a.localeCompare(b));
-    const doors = (await selectDistinctMany(supabase, doorsCols.length ? doorsCols : [columns.doors])).sort((a, b) => a.localeCompare(b));
-    const seating = (await selectDistinctMany(supabase, seatingCols.length ? seatingCols : [columns.seating])).sort((a, b) => a.localeCompare(b));
-    const fuel = (await selectDistinctMany(supabase, fuelCols.length ? fuelCols : [columns.fuel])).sort((a, b) => a.localeCompare(b));
-    const country = (await selectDistinctMany(supabase, countryCols.length ? countryCols : [columns.country])).sort((a, b) => a.localeCompare(b));
-
-    const payload = {
-      columns,
-      options: {
-        year: years,
-        make,
-        model,
-        trim,
-        body,
-        classification,
-        drive,
-        transmission,
-        engine,
-        doors,
-        seating,
-        fuel,
-        country,
+    return NextResponse.json(
+      {
+        options: {
+          year: years,
+          make: makes,
+          model: models,
+          trim: trims,
+          body,
+          classification,
+          drive,
+          transmission,
+          engine,
+          doors,
+          seating,
+          fuel,
+          country,
+        },
       },
-    };
-
-    return new NextResponse(JSON.stringify(payload), {
-      headers: {
-        "content-type": "application/json",
-        "cache-control": "public, s-maxage=900, stale-while-revalidate=86400",
-      },
-    });
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=900, stale-while-revalidate=86400",
+        },
+      }
+    );
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     return new NextResponse(JSON.stringify({ error: message }), { status: 500 });
   }
 }
-
-

--- a/src/app/api/vehicle-data/options/route.ts
+++ b/src/app/api/vehicle-data/options/route.ts
@@ -1,170 +1,30 @@
 import { NextResponse } from "next/server";
-import { getServerSupabase } from "@/lib/supabase";
-
-interface VehicleMake {
-  make: string | null;
-}
-
-interface VehicleModel {
-  model: string | null;
-}
-
-interface VehicleTrim {
-  trim: string | null;
-}
+import { getYears, getMakes, getModels, getTrims } from "@/lib/vehicle-data/options";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
   try {
     const url = new URL(req.url);
-    const scope = url.searchParams.get("scope") || "years"; // years | makes | models | trims
-    const year = url.searchParams.get("year") || "";
-    const make = url.searchParams.get("make") || "";
-    const model = url.searchParams.get("model") || "";
+    const scope = url.searchParams.get("scope") || "years";
+    const year = url.searchParams.get("year") || undefined;
+    const make = url.searchParams.get("make") || undefined;
+    const model = url.searchParams.get("model") || undefined;
 
-    console.log("Vehicle options API called:", { scope, year, make, model });
-
-    const supabase = await getServerSupabase();
     let values: string[] = [];
-
     switch (scope) {
       case "years":
-        // Provide static range for better UX (covers historical to future models)
-        values = Array.from({ length: 2026 - 1990 + 1 }, (_, i) => String(2026 - i));
+        values = await getYears();
         break;
-
       case "makes":
-        // Get distinct makes from existing vehicles
-        let query = supabase
-          .from("vehicle")
-          .select("make")
-          .not("make", "is", null);
-
-        // If year is specified, filter by year
-        if (year) {
-          query = query.eq("year", parseInt(year));
-        }
-
-        const { data: makesData, error: makesError } = await query.order("make");
-
-        console.log("Makes API called with year:", year, "data:", makesData?.length || 0, "items");
-
-        if (makesError) {
-          console.error("Makes query error:", makesError);
-          values = [];
-        } else {
-          // Extract unique makes and normalize
-          const makesSet = new Set<string>();
-          (makesData as VehicleMake[])?.forEach((item: VehicleMake) => {
-            if (item.make) {
-              let make = String(item.make).trim();
-              // Apply normalization like the original code
-              if (make.startsWith("~") && make.endsWith("~")) {
-                make = make.slice(1, -1);
-              }
-              make = make.replace(/\s*\([^)]*\)\s*$/u, "").trim();
-              if (make) makesSet.add(make);
-            }
-          });
-          values = Array.from(makesSet).sort((a, b) => a.localeCompare(b));
-          console.log("Makes processed:", values.length, "unique makes:", values);
-
-          // If no makes found and no year filter, provide some fallback popular makes
-          if (values.length === 0 && !year) {
-            console.log("No makes found, providing fallback makes");
-            values = ["Toyota", "Honda", "Ford", "Chevrolet", "BMW", "Mercedes-Benz", "Audi", "Nissan", "Hyundai", "Kia"];
-          }
-        }
+        values = await getMakes(year);
         break;
-
       case "models":
-        if (!make) {
-          values = [];
-        } else {
-          // Get distinct models for the selected make
-          const { data: modelsData, error: modelsError } = await supabase
-            .from("vehicle")
-            .select("model")
-            .eq("make", make)
-            .not("model", "is", null)
-            .order("model");
-
-          console.log("Models API called for make:", make, "data:", modelsData?.length || 0, "items");
-
-          if (modelsError) {
-            console.error("Models query error:", modelsError);
-            values = [];
-          } else {
-            const modelsSet = new Set<string>();
-            (modelsData as VehicleModel[])?.forEach((item: VehicleModel) => {
-              if (item.model) {
-                const model = String(item.model).trim();
-                if (model) modelsSet.add(model);
-              }
-            });
-            values = Array.from(modelsSet).sort((a, b) => a.localeCompare(b));
-            console.log("Models processed:", values.length, "unique models:", values);
-
-            // If no models found, provide some common models for popular makes
-            if (values.length === 0) {
-              const commonModels: Record<string, string[]> = {
-                "Toyota": ["Camry", "Corolla", "RAV4", "Highlander", "Tacoma"],
-                "Honda": ["Civic", "Accord", "CR-V", "Pilot", "Fit"],
-                "Ford": ["F-150", "Explorer", "Escape", "Mustang", "Focus"],
-                "Chevrolet": ["Silverado", "Equinox", "Malibu", "Traverse", "Tahoe"],
-                "BMW": ["3 Series", "5 Series", "X3", "X5", "7 Series"],
-                "Mercedes-Benz": ["C-Class", "E-Class", "GLC", "GLE", "S-Class"],
-                "Audi": ["A3", "A4", "Q5", "Q7", "A6"],
-                "Nissan": ["Altima", "Sentra", "Rogue", "Pathfinder", "Titan"],
-                "Hyundai": ["Sonata", "Elantra", "Tucson", "Santa Fe", "Kona"],
-                "Kia": ["Sorento", "Sportage", "Telluride", "Soul", "Optima"]
-              };
-              values = commonModels[make] || [`${make} Model`];
-              console.log("No models found, providing fallback models:", values);
-            }
-          }
-        }
+        values = await getModels(year, make);
         break;
-
       case "trims":
-        if (!make || !model) {
-          values = [];
-        } else {
-          // Get distinct trims for the selected make and model
-          const { data: trimsData, error: trimsError } = await supabase
-            .from("vehicle")
-            .select("trim")
-            .eq("make", make)
-            .eq("model", model)
-            .not("trim", "is", null)
-            .order("trim");
-
-          console.log("Trims API called for make:", make, "model:", model, "data:", trimsData?.length || 0, "items");
-
-          if (trimsError) {
-            console.error("Trims query error:", trimsError);
-            values = [];
-          } else {
-            const trimsSet = new Set<string>();
-            (trimsData as VehicleTrim[])?.forEach((item: VehicleTrim) => {
-              if (item.trim) {
-                const trim = String(item.trim).trim();
-                if (trim) trimsSet.add(trim);
-              }
-            });
-            values = Array.from(trimsSet).sort((a, b) => a.localeCompare(b));
-            console.log("Trims processed:", values.length, "unique trims:", values);
-
-            // If no trims found, provide some common trims
-            if (values.length === 0) {
-              values = ["Base", "LX", "EX", "EX-L", "Premium", "Limited", "Platinum"];
-              console.log("No trims found, providing fallback trims:", values);
-            }
-          }
-        }
+        values = await getTrims(year, make, model);
         break;
-
       default:
         values = [];
     }
@@ -173,21 +33,15 @@ export async function GET(req: Request) {
       { values },
       {
         headers: {
-          "Cache-Control": "public, s-maxage=86400, stale-while-revalidate=604800"
-        }
+          "Cache-Control": "public, s-maxage=86400, stale-while-revalidate=604800",
+        },
       }
     );
-
   } catch (error) {
     console.error("Vehicle options API error:", error);
     return NextResponse.json(
       { error: (error as Error).message, values: [] },
-      {
-        status: 500,
-        headers: { "Cache-Control": "public, s-maxage=60" }
-      }
+      { status: 500 }
     );
   }
 }
-
-

--- a/src/components/discover/DiscoverFiltersClient.tsx
+++ b/src/components/discover/DiscoverFiltersClient.tsx
@@ -26,29 +26,32 @@ export default function DiscoverFiltersClient({ options }: { options: Options })
 	const [loaded, setLoaded] = useState(false);
 	const [opts, setOpts] = useState<Options>(options);
 
-	useEffect(() => {
-		let canceled = false;
-		(async () => {
-			try {
-				const url = new URL("/api/discover/filters", window.location.origin);
-				const y = sp.get("year");
-				const mk = sp.get("make");
-				const mdl = sp.get("model");
-				const tr = sp.get("trim");
-				if (y) url.searchParams.set("year", y);
-				if (mk) url.searchParams.set("make", mk);
-				if (mdl) url.searchParams.set("model", mdl);
-				if (tr) url.searchParams.set("trim", tr);
-				const res = await fetch(url.toString(), { cache: "no-store" });
-				const data = await res.json();
-				if (!canceled && data?.options) {
-					setOpts(data.options as Options);
-					setLoaded(true);
-				}
-			} catch {}
-		})();
-		return () => { canceled = true; };
-	}, [sp]);
+        // Fetch filter options from API based on current selections
+        const loadOptions = async () => {
+                const url = new URL("/api/discover/filters", window.location.origin);
+                const y = sp.get("year");
+                const mk = sp.get("make");
+                const mdl = sp.get("model");
+                const tr = sp.get("trim");
+                if (y) url.searchParams.set("year", y);
+                if (mk) url.searchParams.set("make", mk);
+                if (mdl) url.searchParams.set("model", mdl);
+                if (tr) url.searchParams.set("trim", tr);
+                const res = await fetch(url.toString());
+                const data = await res.json();
+                if (data?.options) {
+                        setOpts(data.options as Options);
+                        setLoaded(true);
+                }
+        };
+
+        useEffect(() => {
+                let canceled = false;
+                (async () => {
+                        if (!canceled) await loadOptions();
+                })();
+                return () => { canceled = true; };
+        }, [sp]);
 
 	const replace = (next: URLSearchParams) => {
 		next.set("page", "1");

--- a/src/lib/vehicle-data/options.ts
+++ b/src/lib/vehicle-data/options.ts
@@ -1,0 +1,58 @@
+import { getServerSupabase } from "@/lib/supabase";
+
+// Helper to select distinct values from vehicle_data
+async function distinct(
+  column: string,
+  filters: Record<string, string | number | undefined> = {},
+  sort: { ascending: boolean } = { ascending: true }
+): Promise<string[]> {
+  const supabase = await getServerSupabase();
+  let q = supabase.from("vehicle_data").select(column).not(column, "is", null);
+  for (const [col, val] of Object.entries(filters)) {
+    if (val != null) q = q.eq(col, val);
+  }
+  const { data, error } = await q.order(column, sort).limit(2000);
+  if (error) {
+    console.error("distinct query error", error);
+    return [];
+  }
+  const rows = Array.isArray(data) ? (data as Record<string, unknown>[]) : [];
+  return Array.from(
+    new Set(
+      rows.map((r) => {
+        const v = r[column as keyof typeof r];
+        return v == null ? "" : String(v).trim();
+      })
+    )
+  ).filter(Boolean);
+}
+
+export async function getYears(): Promise<string[]> {
+  const years = await distinct("year", {}, { ascending: false });
+  // Ensure numeric descending order
+  return years.sort((a, b) => Number(b) - Number(a));
+}
+
+export async function getMakes(year?: string): Promise<string[]> {
+  const filters: Record<string, string | number> = {};
+  if (year) filters.year = Number(year);
+  return distinct("make", filters, { ascending: true });
+}
+
+export async function getModels(year?: string, make?: string): Promise<string[]> {
+  const filters: Record<string, string | number> = {};
+  if (year) filters.year = Number(year);
+  if (make) filters.make = make;
+  return distinct("model", filters, { ascending: true });
+}
+
+export async function getTrims(year?: string, make?: string, model?: string): Promise<string[]> {
+  const filters: Record<string, string | number> = {};
+  if (year) filters.year = Number(year);
+  if (make) filters.make = make;
+  if (model) filters.model = model;
+  return distinct("trim", filters, { ascending: true });
+}
+
+export { distinct as getDistinctOptions };
+


### PR DESCRIPTION
## Summary
- centralize vehicle-data option queries in `lib/vehicle-data/options`
- simplify `/api/vehicle-data/options` and `/api/discover/filters` to use helpers
- update clients to fetch option lists from these unified APIs

## Testing
- `npm run lint`
- `npm run test:smoke` *(fails: TypeError: publicTest.describe is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b31b430120832eae4c71783f34ab2d